### PR TITLE
feat: Add reservation CRUD operations and available seats endpoint

### DIFF
--- a/deskops/src/main/java/org/itss/backtoschool/deskops/controller/ReservationController.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/controller/ReservationController.java
@@ -1,13 +1,27 @@
 package org.itss.backtoschool.deskops.controller;
 
 import org.itss.backtoschool.deskops.dto.request.CreateReservationRequest;
+import org.itss.backtoschool.deskops.dto.request.UpdateReservationRequest;
 import org.itss.backtoschool.deskops.dto.response.CreateReservationResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 public interface ReservationController {
 
     @PostMapping
     ResponseEntity<CreateReservationResponse> createReservations(@RequestBody CreateReservationRequest request);
+
+    @GetMapping
+    ResponseEntity<CreateReservationResponse> getAllReservations();
+
+    @GetMapping("/{reservationId}")
+    ResponseEntity<CreateReservationResponse> getReservation(@PathVariable Long reservationId);
+
+    @DeleteMapping("/{reservationId}")
+    ResponseEntity<Void> deleteReservation(@PathVariable Long reservationId);
+
+    @PatchMapping("/{reservationId}")
+    ResponseEntity<CreateReservationResponse> updateReservation(
+            @PathVariable Long reservationId,
+            @RequestBody UpdateReservationRequest request);
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/controller/SeatController.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/controller/SeatController.java
@@ -3,11 +3,18 @@ package org.itss.backtoschool.deskops.controller;
 import org.itss.backtoschool.deskops.dto.SeatDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface SeatController {
 
     @GetMapping
     ResponseEntity<List<SeatDTO>> getAllSeats();
+
+    @GetMapping("/available")
+    ResponseEntity<List<SeatDTO>> getAvailableSeats(
+            @RequestParam LocalDate date,
+            @RequestParam(required = false) Long buildingId);
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/controller/impl/ReservationControllerImpl.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/controller/impl/ReservationControllerImpl.java
@@ -3,6 +3,7 @@ package org.itss.backtoschool.deskops.controller.impl;
 import lombok.RequiredArgsConstructor;
 import org.itss.backtoschool.deskops.controller.ReservationController;
 import org.itss.backtoschool.deskops.dto.request.CreateReservationRequest;
+import org.itss.backtoschool.deskops.dto.request.UpdateReservationRequest;
 import org.itss.backtoschool.deskops.dto.response.CreateReservationResponse;
 import org.itss.backtoschool.deskops.service.ReservationService;
 import org.springframework.http.HttpStatus;
@@ -21,5 +22,29 @@ public class ReservationControllerImpl implements ReservationController {
     public ResponseEntity<CreateReservationResponse> createReservations(CreateReservationRequest request) {
         CreateReservationResponse response = reservationService.createReservations(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Override
+    public ResponseEntity<CreateReservationResponse> getAllReservations() {
+        CreateReservationResponse response = reservationService.getAllReservations();
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<CreateReservationResponse> getReservation(Long reservationId) {
+        CreateReservationResponse response = reservationService.getReservation(reservationId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteReservation(Long reservationId) {
+        reservationService.deleteReservation(reservationId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<CreateReservationResponse> updateReservation(Long reservationId, UpdateReservationRequest request) {
+        CreateReservationResponse response = reservationService.updateReservation(reservationId, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/controller/impl/SeatControllerImpl.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/controller/impl/SeatControllerImpl.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -20,5 +21,10 @@ public class SeatControllerImpl implements SeatController {
     @Override
     public ResponseEntity<List<SeatDTO>> getAllSeats() {
         return ResponseEntity.ok(seatService.getAllSeats());
+    }
+
+    @Override
+    public ResponseEntity<List<SeatDTO>> getAvailableSeats(LocalDate date, Long buildingId) {
+        return ResponseEntity.ok(seatService.getAvailableSeats(date, buildingId));
     }
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/dto/request/UpdateReservationRequest.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/dto/request/UpdateReservationRequest.java
@@ -1,0 +1,15 @@
+package org.itss.backtoschool.deskops.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateReservationRequest {
+    private Long seatId;
+    private LocalDate reservationDate;
+}

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/exception/GlobalExceptionHandler.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.itss.backtoschool.deskops.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.itss.backtoschool.deskops.exception.reservation.ReservationNotFoundException;
 import org.itss.backtoschool.deskops.exception.seat.SeatAlreadyReservedException;
 import org.itss.backtoschool.deskops.exception.seat.SeatNotFoundException;
 import org.itss.backtoschool.deskops.exception.user.UserNotFoundException;
@@ -53,6 +54,19 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(ReservationNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleReservationNotFoundException(ReservationNotFoundException ex, WebRequest request) {
+        log.error("Reservation not found: {}", ex.getMessage());
+
+        var errorResponse = buildErrorResponse(
+                HttpStatus.NOT_FOUND,
+                ex.getMessage(),
+                request.getDescription(false).replace("uri=", "")
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/exception/reservation/ReservationNotFoundException.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/exception/reservation/ReservationNotFoundException.java
@@ -1,0 +1,12 @@
+package org.itss.backtoschool.deskops.exception.reservation;
+
+public class ReservationNotFoundException extends RuntimeException {
+
+    public ReservationNotFoundException() {
+        super("Reservation not found");
+    }
+
+    public ReservationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/exception/seat/SeatAlreadyReservedException.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/exception/seat/SeatAlreadyReservedException.java
@@ -2,4 +2,11 @@ package org.itss.backtoschool.deskops.exception.seat;
 
 public class SeatAlreadyReservedException extends RuntimeException{
 
+    public SeatAlreadyReservedException() {
+        super("This seat is already reserved for the selected date");
+    }
+
+    public SeatAlreadyReservedException(String message) {
+        super(message);
+    }
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/exception/seat/SeatNotFoundException.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/exception/seat/SeatNotFoundException.java
@@ -2,4 +2,11 @@ package org.itss.backtoschool.deskops.exception.seat;
 
 public class SeatNotFoundException extends RuntimeException{
 
+    public SeatNotFoundException() {
+        super("Seat not found");
+    }
+
+    public SeatNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/exception/user/UserNotFoundException.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/exception/user/UserNotFoundException.java
@@ -2,4 +2,11 @@ package org.itss.backtoschool.deskops.exception.user;
 
 public class UserNotFoundException extends RuntimeException{
 
+    public UserNotFoundException() {
+        super("User not found");
+    }
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/repository/SeatRepository.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/repository/SeatRepository.java
@@ -2,8 +2,16 @@ package org.itss.backtoschool.deskops.repository;
 
 import org.itss.backtoschool.deskops.entities.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+
+    @Query("SELECT s FROM Seat s " +
+           "WHERE (:buildingId IS NULL OR s.room.floor.building.id = :buildingId)")
+    List<Seat> findByBuildingId(@Param("buildingId") Long buildingId);
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/service/ReservationService.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/service/ReservationService.java
@@ -1,10 +1,15 @@
 package org.itss.backtoschool.deskops.service;
 
 import org.itss.backtoschool.deskops.dto.request.CreateReservationRequest;
+import org.itss.backtoschool.deskops.dto.request.UpdateReservationRequest;
 import org.itss.backtoschool.deskops.dto.response.CreateReservationResponse;
 
 
 
 public interface ReservationService {
     CreateReservationResponse createReservations(CreateReservationRequest request);
+    CreateReservationResponse getAllReservations();
+    CreateReservationResponse getReservation(Long reservationId);
+    void deleteReservation(Long reservationId);
+    CreateReservationResponse updateReservation(Long reservationId, UpdateReservationRequest request);
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/service/SeatService.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/service/SeatService.java
@@ -2,8 +2,10 @@ package org.itss.backtoschool.deskops.service;
 
 import org.itss.backtoschool.deskops.dto.SeatDTO;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface SeatService {
     List<SeatDTO> getAllSeats();
+    List<SeatDTO> getAvailableSeats(LocalDate date, Long buildingId);
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/service/impl/ReservationServiceImpl.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/service/impl/ReservationServiceImpl.java
@@ -9,6 +9,7 @@ import org.itss.backtoschool.deskops.entities.Reservation;
 import org.itss.backtoschool.deskops.entities.ReservationStatus;
 import org.itss.backtoschool.deskops.entities.Seat;
 import org.itss.backtoschool.deskops.entities.User;
+import org.itss.backtoschool.deskops.exception.reservation.ReservationNotFoundException;
 import org.itss.backtoschool.deskops.exception.seat.SeatAlreadyReservedException;
 import org.itss.backtoschool.deskops.exception.seat.SeatNotFoundException;
 import org.itss.backtoschool.deskops.exception.user.UserNotFoundException;
@@ -97,5 +98,82 @@ public class ReservationServiceImpl implements ReservationService {
 
     private boolean isSeatAlreadyReserved(Long seatId, LocalDate reservationDate) {
         return reservationRepository.existsBySeatIdAndReservationDateAndStatus(seatId, reservationDate, ReservationStatus.ACTIVE);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CreateReservationResponse getAllReservations() {
+        var reservations = reservationRepository.findAll();
+
+        var reservationDTOs = reservations.stream()
+                .map(reservation -> {
+                    var dto = reservationMapper.toDTO(reservation);
+                    enrichWithWeather(dto, reservation);
+                    return dto;
+                })
+                .toList();
+
+        return CreateReservationResponse.builder()
+                .reservations(reservationDTOs)
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CreateReservationResponse getReservation(Long reservationId) {
+        var reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(ReservationNotFoundException::new);
+
+        var dto = reservationMapper.toDTO(reservation);
+        enrichWithWeather(dto, reservation);
+
+        return CreateReservationResponse.builder()
+                .reservations(List.of(dto))
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void deleteReservation(Long reservationId) {
+        var reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(ReservationNotFoundException::new);
+
+        reservation.setStatus(ReservationStatus.CANCELLED);
+        reservationRepository.save(reservation);
+        log.info("Cancelled reservation with ID: {}", reservationId);
+    }
+
+    @Override
+    @Transactional
+    public CreateReservationResponse updateReservation(Long reservationId, org.itss.backtoschool.deskops.dto.request.UpdateReservationRequest request) {
+        var reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(ReservationNotFoundException::new);
+
+        // Check if updating seat or date
+        boolean seatChanged = request.getSeatId() != null && !request.getSeatId().equals(reservation.getSeat().getId());
+        boolean dateChanged = request.getReservationDate() != null && !request.getReservationDate().equals(reservation.getReservationDate());
+
+        if (seatChanged) {
+            var newSeat = seatRepository.findById(request.getSeatId())
+                    .orElseThrow(SeatNotFoundException::new);
+            LocalDate targetDate = request.getReservationDate() != null ? request.getReservationDate() : reservation.getReservationDate();
+            validateSeatAvailability(newSeat, targetDate);
+            reservation.setSeat(newSeat);
+        }
+
+        if (dateChanged) {
+            validateSeatAvailability(reservation.getSeat(), request.getReservationDate());
+            reservation.setReservationDate(request.getReservationDate());
+        }
+
+        reservationRepository.save(reservation);
+        log.info("Updated reservation with ID: {}", reservationId);
+
+        var dto = reservationMapper.toDTO(reservation);
+        enrichWithWeather(dto, reservation);
+
+        return CreateReservationResponse.builder()
+                .reservations(List.of(dto))
+                .build();
     }
 }

--- a/deskops/src/main/java/org/itss/backtoschool/deskops/service/impl/SeatServiceImpl.java
+++ b/deskops/src/main/java/org/itss/backtoschool/deskops/service/impl/SeatServiceImpl.java
@@ -2,11 +2,14 @@ package org.itss.backtoschool.deskops.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.itss.backtoschool.deskops.dto.SeatDTO;
+import org.itss.backtoschool.deskops.entities.ReservationStatus;
 import org.itss.backtoschool.deskops.mapper.SeatMapper;
+import org.itss.backtoschool.deskops.repository.ReservationRepository;
 import org.itss.backtoschool.deskops.repository.SeatRepository;
 import org.itss.backtoschool.deskops.service.SeatService;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -15,10 +18,23 @@ public class SeatServiceImpl implements SeatService {
 
     private final SeatRepository seatRepository;
     private final SeatMapper seatMapper;
+    private final ReservationRepository reservationRepository;
 
     @Override
     public List<SeatDTO> getAllSeats() {
         var seats = seatRepository.findAll();
         return seatMapper.toDTOList(seats);
+    }
+
+    @Override
+    public List<SeatDTO> getAvailableSeats(LocalDate date, Long buildingId) {
+        var seats = seatRepository.findByBuildingId(buildingId);
+
+        var availableSeats = seats.stream()
+                .filter(seat -> !reservationRepository.existsBySeatIdAndReservationDateAndStatus(
+                        seat.getId(), date, ReservationStatus.ACTIVE))
+                .toList();
+
+        return seatMapper.toDTOList(availableSeats);
     }
 }


### PR DESCRIPTION
  Reservation Management:
  - Add GET /api/reservations - Retrieve all reservations
  - Add GET /api/reservations/{id} - Retrieve single reservation by ID
  - Add PATCH /api/reservations/{id} - Partially update reservation (seat and/or date)
  - Add DELETE /api/reservations/{id} - Cancel reservation (soft delete, status -> CANCELLED)
  - Validate seat availability when updating reservations
  - Automatically enrich all reservation responses with weather data

  Available Seats:
  - Add GET /api/seats/available?date={date}&buildingId={id} - Find available seats for booking
  - Filter seats by building (optional)
  - Exclude seats with ACTIVE reservations for the specified date

  Exception Improvements:
  - Add meaningful error messages to all custom exceptions
  - SeatAlreadyReservedException: "This seat is already reserved for the selected date"
  - SeatNotFoundException: "Seat not found"
  - UserNotFoundException: "User not found"
  - ReservationNotFoundException: "Reservation not found"

  Technical Details:
  - Cancelled reservations don't block seat availability
  - Only ACTIVE reservations prevent seat booking
  - Weather data fetched gracefully with fallback on errors